### PR TITLE
mpg123-1.30.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Get an updated config.sub and config.guess
+cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build
+
 ./configure prefix=$PREFIX
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mpg123" %}
-{% set version = "1.25.8" %}
+{% set version = "1.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.bz2
   url: https://sourceforge.net/projects/{{ name }}/files/{{ name }}/{{ version }}/{{ name }}-{{ version }}.tar.bz2/download
-  sha256: 79da51efae011814491f07c95cb5e46de0476aca7a0bf240ba61cfc27af8499b
+  sha256: 397ead52f0299475f2cefd38c3835977193fd9b1db6593680346c4e9109ed61c
 
 build:
     number: 1000
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
+    - libtool  # [unix]
   host:
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 build:
     number: 1000
     skip: true  # [win]
+    error_overlinking: true
 
 requirements:
   build:
@@ -26,8 +27,6 @@ test:
   commands:
     - test -f $PREFIX/lib/libmpg123${SHLIB_EXT}  # [not win]
     - test -f $PREFIX/lib/libout123${SHLIB_EXT}  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [linux]
 
 about:
     home: https://www.mpg123.de/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ about:
     license: LGPL-2.1
     license_family: LGPL
     license_file: COPYING
+    dev_url: https://www.mpg123.de/cgi-bin/scm/mpg123/
+    doc_url: https://www.mpg123.de/api/
     summary: "mpg123 - fast console MPEG Audio Player and decoder library"
 
 extra:


### PR DESCRIPTION
This upgrades the package and additionally enables the `osx-arm64` platform for building.

- [x] Verified local build
- [x] Verified home page URL
- [x] Verified license identifier in SPDX
- [x] Verified package summary
- [x] Verified dev_url (added a new URL)
- [x] Verified doc_url (added a new URL)

In order for the toolchain to be picked up correctly by the build system, `gnuconfig` or `libtool` was needed - I chose `libtool` to be consistent with other recipes in `aggregate`.

I had to remove `conda inspect` tests since it is (for some reason) unavailable on `osx` systems in `prefect`. `overlinking` is the recommended way of testing anyway.